### PR TITLE
[CMS-64] Allow composer 2 in wordpress-composer.

### DIFF
--- a/templates/wordpress-composer/composer.json
+++ b/templates/wordpress-composer/composer.json
@@ -9,7 +9,7 @@
         "wordpress-install-dir": "web/wp"
     },
     "require": {
-        "johnpbloch/wordpress-core-installer": "~0.1"
+        "johnpbloch/wordpress-core-installer": "^2.0"
     },
     "license": [
         "GPL-2.0+"


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Allow composer 2 in wordpress-composer.


