### PR TITLE
Decouple mu-plugin updates from WordPress core updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: write-all
 
+concurrency:
+  group: test-fixtures
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -152,11 +152,6 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         // Find versions in the source that have not been created in the target.
         $versions_to_process = $this->compareTagsSets($source_releases, $existing_releases, $previous_version);
 
-        if (empty($versions_to_process)) {
-            $this->logger->notice("Everything is up-to-date.");
-            return;
-        }
-
         // If we are running in check-only mode, exit now, before we do anything.
         if ($options['check']) {
             return;
@@ -176,6 +171,10 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         $project_working_copy->fetch($upstream_branch, 'upstream');
         $project_working_copy->fetchTags('upstream');
 
+        if (empty($versions_to_process)) {
+            $this->logger->notice("No new version tags to sync.");
+        }
+
         foreach ($versions_to_process as $version => $previous_version) {
             $project_working_copy->switchBranch($version);
 
@@ -185,11 +184,13 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
             }
         }
 
-        // Add commits to main-branch from corresponding branch in upstream.
+        // Always sync main-branch commits from upstream, even when there are no
+        // new version tags — this ensures non-versioned commits (e.g. mu-plugin
+        // updates) are propagated to derivative projects.
         $project_working_copy->switchBranch($main_branch);
         $project_working_copy->pull('upstream', $upstream_branch);
         if (!empty($options['push'])) {
-            $this->logger->notice("Push branch {version} to {target}", ['version' => $main_branch, 'target' => $remote_repo->projectWithOrg()]);
+            $this->logger->notice("Push branch {branch} to {target}", ['branch' => $main_branch, 'target' => $remote_repo->projectWithOrg()]);
             $project_working_copy->push('origin', $main_branch);
         }
     }

--- a/src/Update/Methods/WpCliUpdate.php
+++ b/src/Update/Methods/WpCliUpdate.php
@@ -83,7 +83,6 @@ class WpCliUpdate implements UpdateMethodInterface, LoggerAwareInterface
      */
     public function update(WorkingCopy $originalProject, array $parameters)
     {
-        $forceDbDrop = !empty($parameters['force-db-drop']) ?? false;
         $path = $originalProject->dir();
 
         $wpConfigPath = "$path/wp-config.php";
@@ -100,7 +99,7 @@ class WpCliUpdate implements UpdateMethodInterface, LoggerAwareInterface
         try {
             // Set up a local WordPress site
             $this->wpCoreConfig($path, $this->dbhost, $this->dbname, $this->dbuser, $this->dbpw);
-            $this->wpDbDropIfNotCI($path, $forceDbDrop);
+            $this->wpDbDrop($path);
             $this->wpDbCreate($path);
             $this->wpCoreInstall($path, $this->url, $this->title, $this->admin, $this->adminPw, $this->adminEmail);
 
@@ -110,7 +109,7 @@ class WpCliUpdate implements UpdateMethodInterface, LoggerAwareInterface
         } catch (\Exception $e) {
             throw $e;
         } finally {
-            $this->wpDbDropIfNotCI($path, $forceDbDrop);
+            $this->wpDbDrop($path);
             file_put_contents($wpConfigPath, $wpConfigData);
         }
         return $originalProject;
@@ -157,22 +156,11 @@ class WpCliUpdate implements UpdateMethodInterface, LoggerAwareInterface
     }
 
     /**
-     * Call 'db drop', but only if not running on a CI server
-     */
-    protected function wpDbDropIfNotCI($path, $force = false)
-    {
-        if (!getenv('CI') || $force) {
-            $this->wpDbDrop($path);
-        }
-    }
-
-    /**
-     * Drop any existing database to clean up after previous aborted
-     * runs / at the end of the current run.
+     * Drop the database if it exists.
      */
     protected function wpDbDrop($path)
     {
-        return $this->wpcliReturnStatus($path, 'db drop', ['--yes']);
+        $this->wpcliReturnStatus($path, 'db drop', ['--yes']);
     }
 
     /**

--- a/tests/DerivativePullTest.php
+++ b/tests/DerivativePullTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace UpdateTool;
+
+class DerivativePullTest extends CommandsTestBase
+{
+    use CommandTesterTrait;
+
+    /** @var Fixtures */
+    protected $fixtures;
+
+    // The source fixture and its known tag/branch state.
+    const SOURCE_PROJECT = 'wp';
+    const SOURCE_BRANCH = 'default';
+    const SOURCE_TAG = '4.9.8';
+
+    // The derivative fixture project key in test-configuration.yml.
+    const DERIVATIVE_PROJECT = 'wordpress-network-fixture';
+
+    public function fixtures()
+    {
+        return $this->fixtures;
+    }
+
+    public function setUp()
+    {
+        $commandClasses = [
+            \UpdateTool\Cli\ProjectCommands::class,
+            \Hubph\Cli\HubphCommands::class,
+        ];
+
+        $this->fixtures = new Fixtures();
+        $this->setupCommandTester('TestFixtureApp', '1.0.1', $commandClasses, $this->fixtures->configurationFile());
+    }
+
+    public function tearDown()
+    {
+        $this->fixtures()->deleteDerivativeFixture(self::DERIVATIVE_PROJECT);
+        $this->fixtures()->cleanup();
+    }
+
+    /**
+     * When the derivative already has all tags from the source, derivative:pull
+     * should still sync the main branch — it must not exit early.
+     */
+    public function testDerivativePullSyncsBranchWithNoNewTags()
+    {
+        // Create the fixture with the same tag the source has, so there are no
+        // new tags to process.
+        $this->fixtures()->createDerivativeFixture(
+            self::DERIVATIVE_PROJECT,
+            self::SOURCE_PROJECT,
+            self::SOURCE_BRANCH,
+            [self::SOURCE_TAG]
+        );
+
+        // Give GitHub a moment to settle.
+        sleep(3);
+
+        $configFile = $this->fixtures()->seededConfigurationFile(self::DERIVATIVE_PROJECT);
+        $output = $this->executeExpectOK(['project:derivative:pull', self::DERIVATIVE_PROJECT], null, $configFile);
+
+        $this->assertContains('No new version tags to sync.', $output);
+        $this->assertContains('Push branch master to', $output);
+        $this->assertNotContains('Everything is up-to-date.', $output);
+    }
+
+    /**
+     * When the derivative is missing tags that exist in the source, derivative:pull
+     * should push the missing tags AND still sync the main branch afterward.
+     */
+    public function testDerivativePullSyncsTagsAndBranch()
+    {
+        // Create the fixture with no tags so the source tag is "new" to it.
+        $this->fixtures()->createDerivativeFixture(
+            self::DERIVATIVE_PROJECT,
+            self::SOURCE_PROJECT,
+            self::SOURCE_BRANCH,
+            []
+        );
+
+        // Give GitHub a moment to settle.
+        sleep(3);
+
+        $configFile = $this->fixtures()->seededConfigurationFile(self::DERIVATIVE_PROJECT);
+        $output = $this->executeExpectOK(['project:derivative:pull', self::DERIVATIVE_PROJECT], null, $configFile);
+
+        $this->assertContains('Push tag ' . self::SOURCE_TAG . ' to', $output);
+        $this->assertContains('Push branch master to', $output);
+        $this->assertNotContains('Everything is up-to-date.', $output);
+    }
+}

--- a/tests/ProjectCommandsTest.php
+++ b/tests/ProjectCommandsTest.php
@@ -46,10 +46,8 @@ class ProjectCommandsTest extends CommandsTestBase
         // For some reason, this is ineffective.
         // $this->fixtures()->forceReinitializeDrops8Fixture();
 
-        // Close the open pull requests.
+        // Close the open pull requests and wait until GitHub reflects the closure.
         $this->fixtures()->closeAllOpenPullRequests('drops-8');
-        // Make sure github API has enough time to realize the PR has been closed
-        sleep(5);
 
         // Verify the latest release in our drops-8 and drupal fixtures.
         $output = $this->executeExpectOK(['project:latest', 'drops-8']);
@@ -76,8 +74,8 @@ class ProjectCommandsTest extends CommandsTestBase
         // Ensure that the PR that was created is logged
         $this->assertFileExists($this->fixtures()->activityLogPath());
 
-        // Make sure github API has enough time to realize the PR has been created
-        sleep(5);
+        // GitHub's search API can take 60-90s to index new PRs.
+        sleep(90);
 
         // Try to make another update; confirm that nothing is done
         $output = $this->executeExpectOK(['project:upstream:update', 'drops-8']);
@@ -117,11 +115,8 @@ class ProjectCommandsTest extends CommandsTestBase
      */
     public function testWordPressUpdate()
     {
-        // Closes any leftover PRs in the fixture repository.
+        // Closes any leftover PRs and waits until GitHub reflects the closure.
         $this->fixtures()->closeAllOpenPullRequests('wp');
-
-        // Make sure github API has enough time to realize the PR has been closed
-        sleep(5);
 
         // Create a fork
 //        $wp_repo = $this->fixtures()->forkTestRepo('wp');
@@ -145,8 +140,8 @@ class ProjectCommandsTest extends CommandsTestBase
         // Ensure that the PR that was created is logged
         $this->assertFileExists($this->fixtures()->activityLogPath());
 
-        // Make sure github API has enough time to realize the PR has been created
-        sleep(5);
+        // GitHub's search API can take 60-90s to index new PRs.
+        sleep(90);
 
         // Try to make another update; confirm that nothing is done
         $output = $this->executeExpectOK(['project:upstream:update', 'wp']);

--- a/tests/fixtures/home/test-configuration.yml
+++ b/tests/fixtures/home/test-configuration.yml
@@ -46,3 +46,11 @@ projects:
       url: 'https://raw.githubusercontent.com/pantheon-fixtures/pantheon-wp-fixture/api-fixture/version-check.json'
     release-node:
       atom: 'https://raw.githubusercontent.com/pantheon-fixtures/pantheon-wp-fixture/api-fixture/releases.atom'
+  wordpress-network-fixture:
+    repo: git@github.com:pantheon-fixtures/wordpress-network-fixture.git
+    path: ${working-copy-path}/wordpress-network-fixture
+    main-branch: master
+    source:
+      project: wp
+      branch: default
+      version-pattern: '^4||^5||^6'

--- a/tests/src/Fixtures.php
+++ b/tests/src/Fixtures.php
@@ -20,6 +20,7 @@ class Fixtures
     protected $config;
     protected $logOutput;
     protected $logger;
+    protected $derivativeFixtureUrls = [];
 
     // Our test fixtures' idea of what the current php releases are, frozen in time.
     const PHP_53_CURRENT = '5.3.29';
@@ -121,9 +122,43 @@ class Fixtures
 
         $remote_url = $this->getConfig()->get("projects.$remote_name.repo");
         $remote_repo = Remote::create($remote_url, $api);
+        $org = $remote_repo->org();
+        $project = $remote_repo->project();
+        $projectWithOrg = "$org/$project";
 
-        $allPRs = $api->allPRs($remote_repo->org() . '/' . $remote_repo->project());
-        $api->prClose($remote_repo->org(), $remote_repo->project(), $allPRs);
+        // Use the REST pulls endpoint (not the search API, which has indexing
+        // lag) to get a consistent view of open PRs.
+        $openPRs = $api->gitHubAPI()->api('pull_request')->all($org, $project, ['state' => 'open']);
+        foreach ($openPRs as $pr) {
+            $api->gitHubAPI()->api('pull_request')->update($org, $project, $pr['number'], ['state' => 'closed']);
+        }
+
+        // Poll REST until all PRs are confirmed closed.
+        $maxWait = 60;
+        $waited = 0;
+        while ($waited < $maxWait) {
+            sleep(5);
+            $waited += 5;
+            $remaining = $api->gitHubAPI()->api('pull_request')->all($org, $project, ['state' => 'open']);
+            if (empty($remaining)) {
+                break;
+            }
+        }
+
+        // Also poll the search API (used by matchingPRs) until it stops
+        // returning open PRs for this repo. Search indexing can lag 60-90s
+        // behind REST, causing false "PR already exists" results.
+        $maxWait = 120;
+        $waited = 0;
+        while ($waited < $maxWait) {
+            sleep(10);
+            $waited += 10;
+            $q = "repo:$projectWithOrg is:pr state:open";
+            $searchResults = $api->gitHubAPI()->api('search')->issues($q);
+            if (empty($searchResults['items'])) {
+                return;
+            }
+        }
     }
 
     public function mergeAllOpenPullRequests($remote_name, $as = 'default')
@@ -170,6 +205,125 @@ class Fixtures
         $api->prClose($workingCopy->org(), $workingCopy->project(), $allPRs);
 
         return $workingCopy;
+    }
+
+    /**
+     * Create a new repo in pantheon-fixtures to act as a derivative fixture.
+     * Pushes the given tags and branch (as master) from the source project into it.
+     *
+     * @param string $remote_name Key in test-configuration.yml for the new repo
+     * @param string $source_name Key in test-configuration.yml for the source repo
+     * @param string $source_branch Branch to push from source into the new repo as master
+     * @param array  $tags Tags to push from source into the new repo
+     * @param string $as Auth alias
+     */
+    public function createDerivativeFixture($remote_name, $source_name, $source_branch, array $tags, $as = 'default')
+    {
+        $api = $this->api($as);
+        $config = $this->getConfig();
+
+        $base_url = $config->get("projects.$remote_name.repo");
+        $source_url = $config->get("projects.$source_name.repo");
+
+        // Append the seed to make the repo name unique per test run, since
+        // ${nonce} interpolation does not work with plain config->get().
+        $repo_url = preg_replace('#(\.git)?$#', '-' . $this->seed() . '$1', $base_url, 1);
+
+        if (!preg_match('#github\.com[:/]([^/]+)/([^.]+)#', $repo_url, $m)) {
+            throw new \Exception("Cannot parse repo URL: $repo_url");
+        }
+        $org = $m[1];
+        $repo_name = $m[2];
+
+        // Store the resolved URL so deleteDerivativeFixture and
+        // derivativeConfigurationFile() can reference the same seeded name.
+        $this->derivativeFixtureUrls[$remote_name] = $repo_url;
+
+        // Create empty (no auto_init) so we control the default branch name.
+        $api->gitHubAPI()->api('repo')->create($repo_name, '', '', true, $org, false, false, false, null, false);
+
+        // Clone the source and push into the new empty derivative using
+        // authenticated HTTPS URLs (works in both SSH and token-auth CI envs).
+        $source_path = $this->mktmpdir();
+        rmdir($source_path);
+        $source_url_authed = $api->addTokenAuthentication($source_url);
+        exec("git clone '$source_url_authed' '$source_path' 2>&1", $out, $rc);
+        if ($rc !== 0) {
+            throw new \Exception("Failed to clone source: " . implode("\n", $out));
+        }
+
+        // Push the branch first (initializes the empty repo), then tags.
+        // Use refs/remotes/origin/<branch> since the branch is only a remote
+        // tracking ref after a plain clone — not checked out locally.
+        $auth_push_url = $api->addTokenAuthentication($repo_url);
+        exec("git -C '$source_path' push '$auth_push_url' 'refs/remotes/origin/$source_branch:refs/heads/master' 2>&1", $out, $rc);
+        if ($rc !== 0) {
+            throw new \Exception("Failed to push branch to derivative: " . implode("\n", $out));
+        }
+
+        foreach ($tags as $tag) {
+            exec("git -C '$source_path' push '$auth_push_url' '$tag' 2>&1", $out, $rc);
+            if ($rc !== 0) {
+                throw new \Exception("Failed to push tag $tag to derivative: " . implode("\n", $out));
+            }
+        }
+    }
+
+    /**
+     * Return a path to a full test config file where the placeholder repo URL
+     * for $remote_name has been replaced with the actual seeded URL.
+     * Pass this to executeExpectOK() so the command uses the correct repo.
+     *
+     * @param string $remote_name Key in test-configuration.yml
+     * @return string Path to the seeded config file
+     */
+    public function seededConfigurationFile($remote_name)
+    {
+        $seeded_url = isset($this->derivativeFixtureUrls[$remote_name])
+            ? $this->derivativeFixtureUrls[$remote_name]
+            : null;
+
+        if (!$seeded_url) {
+            throw new \Exception("No seeded URL for $remote_name; call createDerivativeFixture first.");
+        }
+
+        $base = file_get_contents($this->configurationFile());
+        $placeholder_url = $this->getConfig()->get("projects.$remote_name.repo");
+        $seeded = str_replace($placeholder_url, $seeded_url, $base);
+
+        $dir = $this->mktmpdir();
+        $file = $dir . '/' . basename($this->configurationFile());
+        file_put_contents($file, $seeded);
+        return $file;
+    }
+
+    /**
+     * Delete a dynamically created derivative fixture repo from GitHub.
+     *
+     * @param string $remote_name Key in test-configuration.yml for the repo to delete
+     * @param string $as Auth alias
+     */
+    public function deleteDerivativeFixture($remote_name, $as = 'default')
+    {
+        $api = $this->api($as);
+
+        $repo_url = isset($this->derivativeFixtureUrls[$remote_name])
+            ? $this->derivativeFixtureUrls[$remote_name]
+            : null;
+
+        if (!$repo_url) {
+            return;
+        }
+
+        if (!preg_match('#github\.com[:/]([^/]+)/([^.]+)#', $repo_url, $m)) {
+            throw new \Exception("Cannot parse repo URL: $repo_url");
+        }
+
+        try {
+            $api->gitHubAPI()->api('repo')->remove($m[1], $m[2]);
+        } catch (\Exception $e) {
+            // Ignore if the repo never existed (e.g. test failed before creation).
+        }
     }
 
     public function forkTestRepo($remote_name, $as = 'default')

--- a/update-tool.yml
+++ b/update-tool.yml
@@ -47,13 +47,7 @@ projects:
       version-pattern: '#.#.-'
       tags-version-pattern: '^5||^6'
       update-method: WpCliUpdate
-      update-parameters:
-        muplugin:
-          repo: git@github.com:pantheon-systems/pantheon-mu-plugin.git
-          path: ${working-copy-path}/pantheon-mu-plugin
-          muplugin-dir: ${working-copy-path}/WordPress/wp-content/mu-plugins/pantheon-mu-plugin
-      update-filters:
-        - CopyMuPlugin
+      update-filters: []
     pr:
       instructions: |
         Update from WordPress {{original-version}} to WordPress {{update-version}}.


### PR DESCRIPTION
## Summary

- Removes `CopyMuPlugin` from the `wp` upstream update filters so WordPress core update PRs no longer bundle `pantheon-mu-plugin` changes alongside core version bumps.
- Fixes `projectDerivativePull` to always sync the main branch from upstream, even when no new version tags are present. Previously an early return meant non-versioned commits (e.g. standalone mu-plugin updates) would never propagate to derivative projects like `wordpress-network`.

## Context

Part of SITE-1096. MU plugin updates are now managed by a dedicated GitHub Actions workflow in `pantheon-systems/WordPress` that opens standalone PRs to `default` whenever a new `pantheon-mu-plugin` release is published. For that flow to reach derivative projects, the derivative sync must run unconditionally on the main branch.

## Tests

Adds `DerivativePullTest.php` with two integration tests:

**`testDerivativePullSyncsBranchWithNoNewTags`** — Creates the derivative fixture pre-loaded with the same tag as the source (`4.9.8`), so `$versions_to_process` is empty. Asserts the command logs "No new version tags to sync." and still pushes the main branch — confirming the early-return bug is gone.

**`testDerivativePullSyncsTagsAndBranch`** — Creates the derivative fixture with no tags, so `4.9.8` is new to it. Asserts the tag push notice and the branch push notice both appear.

Each test dynamically creates a seeded repo in `pantheon-fixtures`, pushes the desired state from `pantheon-wp-fixture` via authenticated HTTPS, and deletes it in `tearDown`.

Also fixes three pre-existing CI flakiness issues in `ProjectCommandsTest` (concurrent runs, search API indexing lag, WordPress DB re-create error).