### PR TITLE
fix: handle wp.org atom feed 429 errors gracefully

### DIFF
--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -587,9 +587,13 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
 
         // If we can find a release node, then add the "more information" blerb.
         $releaseNode = new ReleaseNode($api);
-        list($failure_message, $release_url) = $releaseNode->get($this->getConfig(), $remote, $major, $latest, empty($update_parameters['allow-pre-release']));
-        if (!empty($release_url)) {
-            $message .= " For more information, see $release_url";
+        try {
+            list($failure_message, $release_url) = $releaseNode->get($this->getConfig(), $remote, $major, $latest, empty($update_parameters['allow-pre-release']));
+            if (!empty($release_url)) {
+                $message .= " For more information, see $release_url";
+            }
+        } catch (NotRecentReleaseException $e) {
+            $this->logger->notice("{version} is not a recent release so no release node link found.", ['version' => $latest]);
         }
 
         $this->logger->notice("Update message: {msg}", ['msg' => $message]);

--- a/src/Util/ReleaseNode.php
+++ b/src/Util/ReleaseNode.php
@@ -115,7 +115,16 @@ class ReleaseNode
         }
         // This only gets us the last ten releases, but that should be
         // enough for our purposes.
-        $atom_contents = file_get_contents($atom_url);
+        $context = stream_context_create([
+            'http' => [
+                'header' => 'User-Agent: pantheon-systems/update-tool',
+            ],
+        ]);
+        $atom_contents = file_get_contents($atom_url, false, $context);
+        if (empty($atom_contents)) {
+            trigger_error("Warning: Failed to fetch atom feed from $atom_url; skipping release node lookup.", E_USER_WARNING);
+            return '';
+        }
         $releases = new \SimpleXMLElement($atom_contents);
         foreach ($releases->entry as $entry) {
             $url = $entry->link['href'];


### PR DESCRIPTION
## Summary

- `ReleaseNode::getViaAtom()` now checks whether `file_get_contents()` returned a falsy value before handing it to `SimpleXMLElement`. On failure it emits a PHP warning and returns `''`, so the caller treats it as "no release URL found" rather than crashing.
- A `User-Agent` header is sent with the atom feed request to reduce the chance of being rate-limited.
- `ProjectCommands::projectUpstreamUpdate()` now wraps the `$releaseNode->get()` call in the same `try-catch (NotRecentReleaseException)` pattern already present in `projectUpstreamPushTags()`, so neither a network error nor a "not a recent release" exception aborts the whole update job — the commit message simply omits the "For more information" link.