### PR TITLE
fix: derivative update fixes for GHA self-hosted runners

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018-2023 Pantheon
+Copyright (c) 2018-2026 Pantheon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -25,7 +25,7 @@ Name                                     Version Licenses
 clue/stream-filter                       v1.5.0  MIT      
 composer/semver                          2.0.0   MIT      
 consolidation/annotated-command          4.4.0   MIT      
-consolidation/config                     2.0.1   MIT      
+consolidation/config                     2.0.6   MIT      
 consolidation/filter-via-dot-access-data 1.0.0   MIT      
 consolidation/log                        2.0.2   MIT      
 consolidation/output-formatters          4.1.2   MIT      
@@ -38,7 +38,7 @@ g1a/hubph                                0.6.6   MIT
 grasmash/expander                        1.0.0   MIT      
 guzzlehttp/guzzle                        6.5.5   MIT      
 guzzlehttp/promises                      1.5.1   MIT      
-guzzlehttp/psr7                          1.8.3   MIT      
+guzzlehttp/psr7                          1.9.1   MIT      
 knplabs/github-api                       v2.20.0 MIT      
 league/container                         2.5.0   MIT      
 php-http/cache-plugin                    1.7.2   MIT      

--- a/composer.lock
+++ b/composer.lock
@@ -206,31 +206,32 @@
         },
         {
             "name": "consolidation/config",
-            "version": "2.0.1",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/config.git",
-                "reference": "9a2c2a7b2aea1b3525984a4378743a8b74c14e1c"
+                "reference": "d90e684c07582ab91916771565f9c768ebfd5dae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/config/zipball/9a2c2a7b2aea1b3525984a4378743a8b74c14e1c",
-                "reference": "9a2c2a7b2aea1b3525984a4378743a8b74c14e1c",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/d90e684c07582ab91916771565f9c768ebfd5dae",
+                "reference": "d90e684c07582ab91916771565f9c768ebfd5dae",
                 "shasum": ""
             },
             "require": {
-                "dflydev/dot-access-data": "^1.1.0",
-                "grasmash/expander": "^1",
+                "dflydev/dot-access-data": "^1.1.0 || ^2 || ^3",
+                "grasmash/expander": "^1 || ^2",
                 "php": ">=7.1.3",
                 "psr/log": "^1.1",
-                "symfony/event-dispatcher": "^4||^5"
+                "symfony/event-dispatcher": "^4 || ^5 || ^6"
             },
             "require-dev": {
+                "ext-json": "*",
                 "phpunit/phpunit": ">=7.5.20",
                 "squizlabs/php_codesniffer": "^3",
-                "symfony/console": "^4||^5",
-                "symfony/yaml": "^4||^5",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "symfony/console": "^4 || ^5 || ^6",
+                "symfony/yaml": "^4 || ^5 || ^6",
+                "yoast/phpunit-polyfills": "^1"
             },
             "suggest": {
                 "symfony/event-dispatcher": "Required to inject configuration into Command options",
@@ -260,9 +261,9 @@
             "description": "Provide configuration services for a commandline tool.",
             "support": {
                 "issues": "https://github.com/consolidation/config/issues",
-                "source": "https://github.com/consolidation/config/tree/2.0.1"
+                "source": "https://github.com/consolidation/config/tree/2.0.6"
             },
-            "time": "2020-12-06T00:03:30+00:00"
+            "time": "2022-02-21T17:36:52+00:00"
         },
         {
             "name": "consolidation/filter-via-dot-access-data",
@@ -5129,15 +5130,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.1.13"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -216,21 +216,22 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         $version_pattern = $this->getConfig()->get("projects.$remote.source.version-pattern", '#.#.#');
         $versionPatternRegex = $this->versionPatternRegex($version_pattern);
 
-
+        $this->logger->notice("Fetching tags for {upstream} and {project}", ['upstream' => $upstream_repo->projectWithOrg(), 'project' => $remote_repo->projectWithOrg()]);
 
         $source_releases = $upstream_repo->tags($versionPatternRegex, empty($update_parameters['allow-pre-release']), '');
         $existing_releases = $remote_repo->tags($versionPatternRegex, empty($update_parameters['allow-pre-release']), '');
 
+        $this->logger->notice("Found {source_count} source tags and {existing_count} existing tags", ['source_count' => count($source_releases), 'existing_count' => count($existing_releases)]);
         $this->logger->notice("Finding missing derived tags for {project}", ['project' => $remote_repo->projectWithOrg()]);
 
         // Get main-branch from config, default to master.
-        $previous_version = $this->getConfig()->get("projects.$remote.main-branch") ?? 'master';
+        $main_branch = $this->getConfig()->get("projects.$remote.main-branch", 'master');
+        $previous_version = $main_branch;
         // Find versions in the source that have not been created in the target.
         $versions_to_process = $this->compareTagsSets($source_releases, $existing_releases, $previous_version);
 
         if (empty($versions_to_process)) {
-            $this->logger->notice("Everything is up-to-date.");
-            return;
+            $this->logger->notice("No new version tags to sync.");
         }
 
         // If we are running in check-only mode, exit now, before we do anything.
@@ -241,7 +242,6 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         $project_url = $this->getConfig()->get("projects.$remote.repo");
         $project_dir = $this->getConfig()->get("projects.$remote.path");
         $project_fork = $this->getConfig()->get("projects.$remote.fork");
-        $main_branch = $this->getConfig()->get("projects.$remote.main-branch", 'master');
 
         $upstream_url = $this->getConfig()->get("projects.$upstream.repo");
         $upstream_dir = $this->getConfig()->get("projects.$upstream.path");
@@ -259,7 +259,10 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         // Create the filters
         $filter_manager = $this->getFilters($this->getConfig()->get("projects.$remote.source.update-filters"));
 
-        $latest_version = '0.0';
+        // Determine the latest source version for main-branch sync.
+        $source_versions = array_keys($source_releases);
+        $latest_version = end($source_versions) ?: '0.0';
+
         foreach ($versions_to_process as $version => $previous_version) {
             if (Comparator::greaterThan($version, $latest_version)) {
                 $latest_version = $version;
@@ -282,13 +285,16 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
             }
         }
 
-        // Add commits to main-branch from latest processed tag.
+        // Always sync main-branch from the latest upstream version, even when
+        // there are no new version tags — this ensures non-versioned changes
+        // (e.g. composer.json updates) are propagated to derivative projects.
+        $this->logger->notice("Syncing {branch} from latest upstream version {version}", ['branch' => $main_branch, 'version' => $latest_version]);
         $project_working_copy->switchBranch($main_branch);
         $upstream_working_copy->switchBranch($latest_version);
-        $this->logger->notice("Processing files from {upstream} {version} over {target} {previous}", ['upstream' => $upstream_repo->projectWithOrg(), 'version' => $latest_version, 'target' => $remote_repo->projectWithOrg(), 'previous' => $previous_version]);
+        $this->logger->notice("Processing files from {upstream} {version} over {target} {branch}", ['upstream' => $upstream_repo->projectWithOrg(), 'version' => $latest_version, 'target' => $remote_repo->projectWithOrg(), 'branch' => $main_branch]);
         $this->applyFiltersAndCommit($filter_manager, $upstream_working_copy, $project_working_copy, $update_parameters);
         if (!empty($options['push'])) {
-            $this->logger->notice("Push branch {version} to {target}", ['version' => $main_branch, 'target' => $remote_repo->projectWithOrg()]);
+            $this->logger->notice("Push branch {branch} to {target}", ['branch' => $main_branch, 'target' => $remote_repo->projectWithOrg()]);
             $project_working_copy->push('origin', $main_branch);
         }
     }

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -168,7 +168,7 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
 
         $project_working_copy = WorkingCopy::cloneBranch($project_url, $project_dir, $main_branch, $api);
         $project_working_copy->addRemote($upstream_url, 'upstream');
-        $project_working_copy->fetch($upstream_branch, 'upstream');
+        $project_working_copy->fetch('upstream', $upstream_branch);
         $project_working_copy->fetchTags('upstream');
 
         if (empty($versions_to_process)) {

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -875,11 +875,18 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         // Apply the filters.
         $filter_manager->apply($upstream_working_copy->dir(), $project_working_copy->dir(), $update_parameters);
 
-        // Commit changes.
+        // Commit changes if there are any.
+        $project_working_copy->addAll();
+        if (empty($project_working_copy->status())) {
+            if (isset($this->logger)) {
+                $this->logger->notice("No changes to commit.");
+            }
+            return false;
+        }
         $comment = $upstream_working_copy->message();
         $commit_date = $upstream_working_copy->commitDate();
-        $project_working_copy->addAll();
         $project_working_copy->commitBy($comment, 'Pantheon Automation <bot@getpantheon.com>', $commit_date);
+        return true;
     }
 
 

--- a/src/Cli/ProjectCommands.php
+++ b/src/Cli/ProjectCommands.php
@@ -167,7 +167,7 @@ class ProjectCommands extends \Robo\Tasks implements ConfigAwareInterface, Logge
         $this->logger->notice("Cloning repository for {remote} and fetching needed branch and tags", ['remote' => $remote]);
 
         $project_working_copy = WorkingCopy::cloneBranch($project_url, $project_dir, $main_branch, $api);
-        $project_working_copy->addRemote($upstream_url, 'upstream');
+        $project_working_copy->addRemote($upstream_repo->url(), 'upstream');
         $project_working_copy->fetch('upstream', $upstream_branch);
         $project_working_copy->fetchTags('upstream');
 

--- a/src/Git/WorkingCopy.php
+++ b/src/Git/WorkingCopy.php
@@ -273,7 +273,7 @@ class WorkingCopy implements LoggerAwareInterface
      */
     public function fetchTags($remote = 'origin')
     {
-        $this->fetch($remote, '--tags');
+        $this->git('fetch --tags --force {remote}', ['remote' => $remote]);
         return $this;
     }
 

--- a/src/Git/WorkingCopy.php
+++ b/src/Git/WorkingCopy.php
@@ -621,7 +621,7 @@ class WorkingCopy implements LoggerAwareInterface
      */
     public function git($cmd, $replacements = [], $redacted = [])
     {
-        return $this->execWithRedaction('git {dir}' . $cmd, ['dir' => "-C {$this->dir} "] + $replacements, ['dir' => ''] + $redacted);
+        return $this->execWithRedaction('git {dir}' . $cmd, ['dir' => "-C {$this->dir} "] + $replacements, $redacted);
     }
 
     /**

--- a/src/Update/Filters/RsyncFromSource.php
+++ b/src/Update/Filters/RsyncFromSource.php
@@ -42,6 +42,12 @@ class RsyncFromSource implements UpdateFilterInterface, LoggerAwareInterface
             )
         );
 
-        exec("rsync $options $src/ $dest >/dev/null 2>&1");
+        if ($this->logger) {
+            $this->logger->notice("rsync from {src} to {dest}", ['src' => "$src/", 'dest' => $dest]);
+        }
+        exec("rsync $options $src/ $dest 2>&1", $output, $result);
+        if ($result !== 0) {
+            throw new \RuntimeException("rsync failed with exit code $result: " . implode("\n", $output));
+        }
     }
 }

--- a/update-tool.yml
+++ b/update-tool.yml
@@ -45,7 +45,7 @@ projects:
       repo: git@github.com:WordPress/WordPress.git
       major: '[4-9]'
       version-pattern: '#.#.-'
-      tags-version-pattern: '^5||^6'
+      tags-version-pattern: '^5||^6||^7'
       update-method: WpCliUpdate
       update-filters: []
     pr:
@@ -109,7 +109,7 @@ projects:
     path: ${working-copy-path}/wordpress-composer
     source:
       project: wp
-      version-pattern: '^5||^6'
+      version-pattern: '^5||^6||^7'
       update-parameters:
         rsync:
           options: '-ravz --delete'
@@ -127,7 +127,7 @@ projects:
     main-branch: master
     source:
       project: wp
-      version-pattern: '^5||^6'
+      version-pattern: '^5||^6||^7'
       branch: master
   drops-8-scaffolding:
     repo: git@github.com:pantheon-systems/drops-8-scaffolding.git


### PR DESCRIPTION
## Summary

Fixes multiple bugs in the derivative update pipeline (`project:derivative:update` and `project:derivative:pull`). Most of these were pre-existing but hidden by exit code suppression in `WorkingCopy::git()` — they became visible once that was fixed. The rsync issue was introduced by the CircleCI → GHA migration (the self-hosted runner lacks `rsync`).

### Behavioral changes

- **`projectDerivativeUpdate` now always syncs the main branch** from the latest upstream version, even when no new version tags exist. Previously it returned early, which meant non-versioned changes (e.g. mu-plugin updates, composer.json changes) were never propagated to derivative projects.
- **`applyFiltersAndCommit` is now idempotent** — checks `git status` before committing, returns `false` when the working tree is clean.

### Bug fixes

- **`WorkingCopy::git()` masked all exit codes** by passing `['dir' => '']` in `$redacted`, which caused every git command to pipe through `2>&1 | sed ...`. The `sed` exit code (always 0) replaced git's exit code, so `git push` failures were invisible.
- **`RsyncFromSource` swallowed errors** via `>/dev/null 2>&1` with no exit code check. On the self-hosted runner where `rsync` is not installed, this silently returned exit code 127 and copied nothing.
- **`projectDerivativePull` had reversed `fetch()` arguments** — called `fetch($branch, 'upstream')` instead of `fetch('upstream', $branch)`, producing `git fetch --no-tags master upstream`.
- **`projectDerivativePull` used unauthenticated URL for upstream remote** — `addRemote` used the raw SSH URL from config instead of the authenticated URL from `createRemote`. When `GITHUB_TOKEN` is set (e.g. in CI tests), the upstream remote needs HTTPS+token auth.
- **`fetchTags()` failed on cached working copies** when local tags conflicted with upstream. Changed from routing through `fetch()` (which prepended `--no-tags`) to a direct `git fetch --tags --force`.

### Other

- Updated `version-pattern` to include WordPress 7.x (`'^5||^6||^7'`).
- Updated `consolidation/config` from 2.0.1 to 2.0.6 for PHP 8.2 compatibility.