### PR TITLE
ci: use github.token for send-dispatch instead of PAT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,13 @@ jobs:
   send-dispatch:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Send Dispatch
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
-          token: ${{ secrets.PANTHEON_UPSTREAM_AUTH_TOKEN }}
+          token: ${{ github.token }}
           repository: pantheon-systems/update-tool
           event-type: tests-passed
           client-payload: '{"tag_name": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

- Replace `PANTHEON_UPSTREAM_AUTH_TOKEN` with `github.token` in the `send-dispatch` job
- Add job-level `permissions: contents: write` so `github.token` has the write access needed to trigger `repository_dispatch` on the same repo
- Top-level `permissions: contents: read` unchanged; only `send-dispatch` is elevated

## Context

`send-dispatch` dispatches to `pantheon-systems/update-tool` (itself). Using a PAT for a same-repo dispatch is an oversight — `github.token` already has the necessary access when given `contents: write` at the job level.

Spotted by Phil Tyler after the 0.8.3 manual release (the PAT scoped to `pantheon-fixtures` couldn't trigger dispatch on `update-tool`).