### PR TITLE
ci(SITE-5866): explicitly download phar-composer for phar build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Build phar
         run: |
           composer install
+          curl -sL https://github.com/clue/phar-composer/releases/download/v1.4.0/phar-composer-1.4.0.phar -o vendor/bin/phar-composer.phar
+          chmod +x vendor/bin/phar-composer.phar
           composer phar:build
       - name: Publish Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Build phar
         run: |
           composer install
-          curl -sL https://github.com/clue/phar-composer/releases/download/v1.4.0/phar-composer-1.4.0.phar -o vendor/bin/phar-composer.phar
-          chmod +x vendor/bin/phar-composer.phar
           composer phar:build
       - name: Publish Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
         "symfony/filesystem": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6|^10.0",
+        "clue/phar-composer": "^1.4",
         "g1a/composer-test-scenarios": "^2",
         "php-coveralls/php-coveralls": "^2.7",
+        "phpunit/phpunit": "^9.6|^10.0",
         "squizlabs/php_codesniffer": "^3"
     },
     "bin": [
@@ -40,7 +41,7 @@
     "scripts": {
         "phar:build": [
             "rm -Rf ./update-tool.phar",
-            "php -d phar.readonly=off vendor/bin/phar-composer.phar build .",
+            "php -d phar.readonly=off vendor/bin/phar-composer build .",
             "chmod +x update-tool.phar"
         ],
         "cs": "phpcs --standard=PSR2 -n src",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "026f859a0b3db0d7f02239cb02e919f9",
+    "content-hash": "b2c52800079ef410cb9c57473397da7f",
     "packages": [
         {
             "name": "composer/semver",
@@ -2831,6 +2831,164 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/phar-composer",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/phar-composer.git",
+                "reference": "0cae6984e0da45639881d3b26442d525b8b65406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/phar-composer/zipball/0cae6984e0da45639881d3b26442d525b8b65406",
+                "reference": "0cae6984e0da45639881d3b26442d525b8b65406",
+                "shasum": ""
+            },
+            "require": {
+                "knplabs/packagist-api": "^1.0",
+                "php": ">=5.3.6",
+                "symfony/console": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",
+                "symfony/finder": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5",
+                "symfony/process": "^6.0 || ^5.0 || ^4.0 || ^3.0 || ^2.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.36"
+            },
+            "bin": [
+                "bin/phar-composer"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\PharComposer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Simple phar creation for any project managed via Composer",
+            "homepage": "https://github.com/clue/phar-composer",
+            "keywords": [
+                "build process",
+                "bundle dependencies",
+                "composer",
+                "executable phar",
+                "phar"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/phar-composer/issues",
+                "source": "https://github.com/clue/phar-composer/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-14T11:28:08+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T19:31:58+00:00"
+        },
+        {
             "name": "g1a/composer-test-scenarios",
             "version": "2.2.0",
             "source": {
@@ -2866,6 +3024,63 @@
                 "source": "https://github.com/g1a/composer-test-scenarios/tree/keep"
             },
             "time": "2018-08-08T23:37:23+00:00"
+        },
+        {
+            "name": "knplabs/packagist-api",
+            "version": "v1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/packagist-api.git",
+                "reference": "4feae228a4505c1cd817da61e752e5dea2b22c2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/packagist-api/zipball/4feae228a4505c1cd817da61e752e5dea2b22c2d",
+                "reference": "4feae228a4505c1cd817da61e752e5dea2b22c2d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.0 || ^2.0",
+                "guzzlehttp/guzzle": "^6.0 || ^7.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Packagist\\Api\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                }
+            ],
+            "description": "Packagist API client.",
+            "homepage": "http://knplabs.com",
+            "keywords": [
+                "api",
+                "composer",
+                "packagist"
+            ],
+            "support": {
+                "issues": "https://github.com/KnpLabs/packagist-api/issues",
+                "source": "https://github.com/KnpLabs/packagist-api/tree/v1.7.2"
+            },
+            "time": "2022-03-01T08:20:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4852,5 +5067,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

- `publish.yml` phar build broke after #145 regenerated `composer.lock`
- Previously `tm/tooly-composer-script` (transitive dep of `g1a/composer-test-scenarios`) ran a post-install hook that downloaded `phar-composer.phar` into `vendor/bin/`
- #145 updated deps, dropping tooly as a transitive dep and removing the `extra.tools` config block — so `composer install` no longer downloads the build tool
- Fix: explicitly download phar-composer v1.4.0 from GitHub releases before building

## Context

[SITE-5866](https://getpantheon.atlassian.net/browse/SITE-5866)

Every release before 0.8.3 had a `update-tool.phar` asset (Deploy workflow succeeded). 0.8.4 tag push confirmed send-dispatch now works (pantheon-systems/update-tool#147), but Deploy fails at `Could not open input file: vendor/bin/phar-composer.phar`.

Pinned to v1.4.0 (the version tooly was previously downloading via `https://clue.engineering/phar-composer-latest.phar` redirect). Using GitHub releases URL instead of the personal domain.

## Test plan

- [ ] Merge, push a tag, verify Deploy workflow runs and produces `update-tool.phar` release asset

[SITE-5866]: https://getpantheon.atlassian.net/browse/SITE-5866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ